### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -21,12 +21,8 @@
     "native": [
       "{projectRoot}/**/*.rs",
       "{projectRoot}/**/Cargo.*",
-      {
-        "runtime": "node -p '`${process.platform}_${process.arch}`'"
-      },
-      {
-        "externalDependencies": ["npm:@monodon/rust", "npm:@napi-rs/cli"]
-      }
+      { "runtime": "node -p '`${process.platform}_${process.arch}`'" },
+      { "externalDependencies": ["npm:@monodon/rust", "npm:@napi-rs/cli"] }
     ],
     "e2eInputs": [
       "default",
@@ -34,36 +30,19 @@
       "{workspaceRoot}/.verdaccio/config.yml",
       "{workspaceRoot}/scripts/local-registry/**/*",
       "{workspaceRoot}/scripts/nx-release.ts",
-      {
-        "env": "SELECTED_CLI"
-      },
-      {
-        "env": "SELECTED_PM"
-      },
-      {
-        "env": "NX_E2E_CI_CACHE_KEY"
-      },
-      {
-        "env": "CI"
-      },
-      {
-        "env": "NX_E2E_RUN_E2E"
-      }
+      { "env": "SELECTED_CLI" },
+      { "env": "SELECTED_PM" },
+      { "env": "NX_E2E_CI_CACHE_KEY" },
+      { "env": "CI" },
+      { "env": "NX_E2E_RUN_E2E" }
     ]
   },
   "release": {
     "projects": ["packages/*", "packages/nx/native-packages/*"],
     "releaseTagPattern": "{version}",
     "changelog": {
-      "workspaceChangelog": {
-        "createRelease": "github",
-        "file": false
-      },
-      "git": {
-        "commit": false,
-        "stageChanges": false,
-        "tag": false
-      }
+      "workspaceChangelog": { "createRelease": "github", "file": false },
+      "git": { "commit": false, "stageChanges": false, "tag": false }
     },
     "version": {
       "generatorOptions": {
@@ -71,28 +50,19 @@
         "currentVersionResolver": "registry",
         "skipLockFileUpdate": true
       },
-      "git": {
-        "commit": false,
-        "stageChanges": false,
-        "tag": false
-      }
+      "git": { "commit": false, "stageChanges": false, "tag": false }
     }
   },
   "targetDefaults": {
     "nx-release-publish": {
-      "options": {
-        "packageRoot": "build/packages/{projectName}"
-      }
+      "options": { "packageRoot": "build/packages/{projectName}" }
     },
     "build": {
       "dependsOn": ["build-base", "build-native"],
       "inputs": ["production", "^production"],
       "cache": true
     },
-    "build-native": {
-      "inputs": ["native"],
-      "cache": true
-    },
+    "build-native": { "inputs": ["native"], "cache": true },
     "build-base": {
       "dependsOn": ["^build-base", "build-native"],
       "inputs": ["production", "^production"],
@@ -125,28 +95,16 @@
         "@nx/nx-source:lint-pnpm-lock"
       ]
     },
-    "lint-pnpm-lock": {
-      "cache": true
-    },
-    "e2e": {
-      "cache": true,
-      "inputs": ["e2eInputs", "^production"]
-    },
-    "e2e-local": {
-      "cache": true,
-      "inputs": ["e2eInputs", "^production"]
-    },
-    "e2e-ci": {
-      "inputs": ["e2eInputs", "^production"]
-    },
+    "lint-pnpm-lock": { "cache": true },
+    "e2e": { "cache": true, "inputs": ["e2eInputs", "^production"] },
+    "e2e-local": { "cache": true, "inputs": ["e2eInputs", "^production"] },
+    "e2e-ci": { "inputs": ["e2eInputs", "^production"] },
     "e2e-macos-local": {
       "cache": true,
       "inputs": ["e2eInputs", "^production"],
       "parallelism": false
     },
-    "e2e-macos-ci": {
-      "inputs": ["e2eInputs", "^production"]
-    },
+    "e2e-macos-ci": { "inputs": ["e2eInputs", "^production"] },
     "e2e-ci--**/**": {
       "inputs": ["e2eInputs", "^production"],
       "parallelism": false,
@@ -157,9 +115,7 @@
       "parallelism": false,
       "dependsOn": ["@nx/nx-source:populate-local-registry-storage"]
     },
-    "e2e-base": {
-      "inputs": ["default", "^production"]
-    },
+    "e2e-base": { "inputs": ["default", "^production"] },
     "build-storybook": {
       "inputs": [
         "default",
@@ -170,31 +126,20 @@
       ],
       "cache": true
     },
-    "build-ng": {
-      "cache": true
-    },
-    "sitemap": {
-      "cache": true
-    },
-    "copy-docs": {
-      "cache": true
-    }
+    "build-ng": { "cache": true },
+    "sitemap": { "cache": true },
+    "copy-docs": { "cache": true }
   },
   "plugins": [
     "@monodon/rust",
     {
       "plugin": "@nx/playwright/plugin",
-      "options": {
-        "targetName": "pw-e2e",
-        "ciTargetName": "e2e-ci"
-      }
+      "options": { "targetName": "pw-e2e", "ciTargetName": "e2e-ci" }
     },
     {
       "plugin": "@nx/eslint/plugin",
       "exclude": ["packages/**/__fixtures__/**/*"],
-      "options": {
-        "targetName": "lint"
-      }
+      "options": { "targetName": "lint" }
     },
     {
       "plugin": "@nx/jest/plugin",
@@ -203,9 +148,7 @@
         "packages/**/__fixtures__/**/*",
         "jest.config.ts"
       ],
-      "options": {
-        "targetName": "test"
-      }
+      "options": { "targetName": "test" }
     },
     {
       "plugin": "@nx/webpack/plugin",
@@ -218,10 +161,7 @@
       "plugin": "@nx/jest/plugin",
       "include": ["e2e/**/*"],
       "exclude": ["e2e/detox/**/*", "e2e/react-native/**/*", "e2e/expo/**/*"],
-      "options": {
-        "targetName": "e2e-local",
-        "ciTargetName": "e2e-ci"
-      }
+      "options": { "targetName": "e2e-local", "ciTargetName": "e2e-ci" }
     },
     {
       "plugin": "@nx/jest/plugin",
@@ -242,7 +182,7 @@
     },
     "@nx/powerpack-enterprise-cloud"
   ],
-  "nxCloudId": "62d013ea0852fe0a2df74438",
+  "nxCloudId": "67c3d10b2152080eb3e132b6",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
   "bust": 5,
@@ -252,9 +192,7 @@
       {
         "rule": "@nx/workspace-plugin/conformance-rules/blog-description",
         "projects": ["docs"],
-        "options": {
-          "mdGlobPattern": "blog/**/*.md"
-        }
+        "options": { "mdGlobPattern": "blog/**/*.md" }
       },
       {
         "rule": "@nx/workspace-plugin/conformance-rules/project-package-json",

--- a/nx.json
+++ b/nx.json
@@ -182,7 +182,7 @@
     },
     "@nx/powerpack-enterprise-cloud"
   ],
-  "nxCloudId": "67c3d10b2152080eb3e132b6",
+  "nxCloudId": "67c3d71bda66fe6aba435f18",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
   "bust": 5,


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/67c3c5452152080eb3e132a3/workspaces/67c3d71bda66fe6aba435f18

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.